### PR TITLE
A better suggestion about the annotation usage

### DIFF
--- a/src/main/java/springboot/service/impl/RedisService.java
+++ b/src/main/java/springboot/service/impl/RedisService.java
@@ -2,7 +2,7 @@ package springboot.service.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import java.util.Collection;
 import java.util.Date;
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@Component
+@Service
 public class RedisService {
     @Autowired
     private RedisTemplate<String, String> redisTemplate;


### PR DESCRIPTION
Hi, I found that there may be some minor improvements about annotations in your code. 

A Spring bean in the service layer should be annotated using @Service instead of @Component annotation.
@Service annotation is a specialization of @Component in service layer. By using a specialized annotation we hit two birds with one stone. First, they are treated as Spring bean, and second, you can put special behavior required by that layer.

For better understanding and maintainability of a large application, @Service is a better choice.